### PR TITLE
Bump Unity Atoms version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
     "dependencies": {
       "com.unity.visualscripting": "1.7.6",
-      "com.unity-atoms.unity-atoms-base-atoms": "4.4.2",
+      "com.unity-atoms.unity-atoms-base-atoms": "4.4.3",
       "com.realitystop.linkmerge": "1.0.0"
     }
 }


### PR DESCRIPTION
Unity Atoms currently has [3 published versions](https://openupm.com/packages/com.unity-atoms.unity-atoms-base-atoms/?subPage=versions), which do not include 4.4.2, so installing this package via the recommended OpenUPM path results in a 404 error.